### PR TITLE
Add Matrix data structure for python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ target/
 .scala_dependencies
 .cache-main
 *.class
+
+# python
+
+src/main/python/__pycache__
+src/test/python/__pycache__
+

--- a/src/main/python/matrix.py
+++ b/src/main/python/matrix.py
@@ -48,6 +48,19 @@ class Matrix:
             output.append(slice_portion)
             
         return tuple(output)
+    
+    def slice_vh(self, start_row, end_row, start_column, end_column, step_row=1, step_column=1):
+        return self.slice_h(start_row, end_row, step_row).slice_v(start_column, end_column, step_column)
+    
+    def split_vh(self, n, m):
+        return tuple(mat.split_v(m) for mat in self.split_h(n))
+        
+    def split_vh_flat(self, n, m):
+        result = ()
+        for line in self.split_vh(n, m):
+            result += line
+            
+        return result
         
     def __str__(self):
         return self.as_tuple().__str__()

--- a/src/main/python/matrix.py
+++ b/src/main/python/matrix.py
@@ -11,10 +11,10 @@ class Matrix:
         self.n_columns = 0 if self.n_rows == 0 else len(lines[0])
         
     def as_tuple(self):
-        return tuple(tuple(line) for line in lines)
+        return tuple(tuple(line) for line in self.lines)
 
     def __getitem__(self, key):
-        return tuple(self.lines[key])
+        return tuple(self.lines[key]) 
     
     def slice_v(self, start, end, step=1):
         new_lines = [line[start:end:step] for line in self.lines]
@@ -29,6 +29,31 @@ class Matrix:
             end_index = min(start_index + step, self.n_columns)
             slice_portion = self.slice_v(start_index, end_index)
             output.append(slice_portion)
+            start_index += step
             
         return tuple(output)
+        
+    def slice_h(self, start, end, step=1):
+        return Matrix(self.lines[start:end:step])
             
+    
+    def split_h(self, n):
+        
+        output = []
+        step = math.ceil(self.n_rows / n)
+        
+        for start_index in range(0, self.n_rows, step):
+            end_index = min(start_index + step, self.n_rows)
+            slice_portion = self.slice_h(start_index, end_index)
+            output.append(slice_portion)
+            
+        return tuple(output)
+        
+    def __str__(self):
+        return self.as_tuple().__str__()
+        
+    def __repr__(self):
+        return self.as_tuple().__repr__()
+        
+    def __eq__(self, other):
+        return self.as_tuple() == other.as_tuple()

--- a/src/main/python/matrix.py
+++ b/src/main/python/matrix.py
@@ -6,7 +6,7 @@ class Matrix:
     This data structure is immutable.
     """
     def __init__(self, lines=[]):
-        self.lines = lines
+        self.lines = list(lines)
         self.n_rows = len(lines)
         self.n_columns = 0 if self.n_rows == 0 else len(lines[0])
         

--- a/src/main/python/matrix.py
+++ b/src/main/python/matrix.py
@@ -1,0 +1,34 @@
+import math
+
+class Matrix:
+    """
+    Simple representation of a matrix of arbitrary fixed size with basic functions commonly used in D&C algorithms.
+    This data structure is immutable.
+    """
+    def __init__(self, lines=[]):
+        self.lines = lines
+        self.n_rows = len(lines)
+        self.n_columns = 0 if self.n_rows == 0 else len(lines[0])
+        
+    def as_tuple(self):
+        return tuple(tuple(line) for line in lines)
+
+    def __getitem__(self, key):
+        return tuple(self.lines[key])
+    
+    def slice_v(self, start, end, step=1):
+        new_lines = [line[start:end:step] for line in self.lines]
+        return Matrix(new_lines)
+    
+    
+    def split_v(self, n):
+        step = math.ceil(self.n_columns / n)
+        output = []
+        start_index = 0
+        for i in range(n):
+            end_index = min(start_index + step, self.n_columns)
+            slice_portion = self.slice_v(start_index, end_index)
+            output.append(slice_portion)
+            
+        return tuple(output)
+            

--- a/src/test/python/matrix_test.py
+++ b/src/test/python/matrix_test.py
@@ -117,6 +117,83 @@ class MatrixTest(unittest.TestCase):
         
         self.assertEqual(m1.split_h(3), expected)
 
+    def test_matrix_vh_slicing_works(self):
+    
+        m1 = Matrix([[1, 2, 3, 4, 5],
+                     [6, 7, 8, 9, 0],
+                     [7, 6, 5, 4, 3]])
+                     
+        expected = ((8, 9), 
+                    (5, 4)) 
+                     
+        self.assertEqual(m1.slice_vh(1, 3, 2, 4).as_tuple(), expected)
+
+    def test_matrix_vh_splitting_works(self):
+    
+        m1 = Matrix([[1, 2, 3, 4, 2],
+                     [6, 7, 8, 9, 1],
+                     [7, 6, 5, 4, 3],
+                     [3, 2, 8, 7, 9],
+                     [1, 8, 9, 3, 5]])
+                     
+        expected1 = (
+        
+            (Matrix([[1, 2], 
+                     [6, 7]]),
+                    
+            Matrix([[3, 4], 
+                    [8, 9]]),
+                    
+            Matrix([[2], 
+                    [1]])),
+                    
+            (Matrix([[7, 6], 
+                     [3, 2]]),
+                    
+            Matrix([[5, 4], 
+                    [8, 7]]),
+                    
+            Matrix([[3], 
+                    [9]])),
+                    
+            (Matrix([[1, 8]]),
+                    
+            Matrix([[9, 3]]),
+                    
+            Matrix([[5]]))        
+
+        )
+        
+        expected2 = (
+        
+            Matrix([[1, 2], 
+                     [6, 7]]),
+                    
+            Matrix([[3, 4], 
+                    [8, 9]]),
+                    
+            Matrix([[2], 
+                    [1]]),
+                    
+            Matrix([[7, 6], 
+                     [3, 2]]),
+                    
+            Matrix([[5, 4], 
+                    [8, 7]]),
+                    
+            Matrix([[3], 
+                    [9]]),
+                    
+            Matrix([[1, 8]]),
+                    
+            Matrix([[9, 3]]),
+                    
+            Matrix([[5]])        
+
+        )
+        
+        self.assertEqual(m1.split_vh(3, 3), expected1)
+        self.assertEqual(m1.split_vh_flat(3, 3), expected2)
         
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/python/matrix_test.py
+++ b/src/test/python/matrix_test.py
@@ -1,0 +1,27 @@
+import unittest
+import sys
+
+sys.path.insert(0, '../../main/python')
+
+from matrix import Matrix
+
+
+class MatrixTest(unittest.TestCase):
+
+        
+    def test_matrix_parameters_are_correctly_set(self):
+    
+        m1 = Matrix()
+        m2 = Matrix([[1,2,3],
+                     [4,5,6]])
+                
+        self.assertEqual(m1.n_rows,    0)
+        self.assertEqual(m1.n_columns, 0)
+        
+        self.assertEqual(m2.n_rows,    2)
+        self.assertEqual(m2.n_columns, 3)
+        
+        
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/python/matrix_test.py
+++ b/src/test/python/matrix_test.py
@@ -21,7 +21,102 @@ class MatrixTest(unittest.TestCase):
         self.assertEqual(m2.n_rows,    2)
         self.assertEqual(m2.n_columns, 3)
         
+    
+    def test_matrix_tuple_retrieval_works(self):
+    
+        m1 = Matrix([[1,2,3],
+                     [4,5,6]])
+                     
+        expected = ((1,2,3), (4,5,6))
         
+        self.assertEqual(m1.as_tuple(), expected)
+    
+    def test_matrix_indexing_works(self):
+    
+        m1 = Matrix([[1,2,3],
+                     [4,5,6]])
+                     
+        self.assertEqual(m1[0][1], 2)
+        self.assertEqual(m1[1][2], 6)
+        
+        
+    def test_matrix_vertical_slicing_works(self):
+    
+        m1 = Matrix([[1, 2, 3, 4, 5],
+                     [6, 7, 8, 9, 0],
+                     [7, 6, 5, 4, 3]])
+                     
+        expected1 = ((2, 3), 
+                     (7, 8), 
+                     (6, 5))
+        expected2 = ((2, 4), 
+                     (7, 9), 
+                     (6, 4))  
+                     
+        self.assertEqual(m1.slice_v(1, 3).as_tuple(), expected1)
+        self.assertEqual(m1.slice_v(1, 4, 2).as_tuple(), expected2)
+    
+    def test_matrix_vertical_splitting_works(self):
+    
+        m1 = Matrix([[1, 2, 3, 4, 5],
+                     [6, 7, 8, 9, 0],
+                     [7, 6, 5, 4, 3]])
+                     
+        expected = (
+        
+            Matrix([[1, 2], 
+                    [6, 7], 
+                    [7, 6]]),
+                    
+            Matrix([[3, 4], 
+                    [8, 9], 
+                    [5, 4]]),
+                    
+            Matrix([[5], 
+                    [0], 
+                    [3]])
+
+        )
+        
+        self.assertEqual(m1.split_v(3), expected)
+        
+    def test_matrix_horizontal_slicing_works(self):
+    
+        m1 = Matrix([[1, 2, 3, 4, 5],
+                     [6, 7, 8, 9, 0],
+                     [7, 6, 5, 4, 3]])
+                     
+        expected1 = ((1, 2, 3, 4, 5), 
+                     (6, 7, 8, 9, 0))
+                     
+        expected2 = ((1, 2, 3, 4, 5), 
+                     (7, 6, 5, 4, 3)) 
+                     
+        self.assertEqual(m1.slice_h(0, 2).as_tuple(), expected1)
+        self.assertEqual(m1.slice_h(0, 3, 2).as_tuple(), expected2)
+    
+    def test_matrix_horizontal_splitting_works(self):
+    
+        m1 = Matrix([[1, 2, 3],
+                     [6, 7, 8],
+                     [7, 6, 5],
+                     [4, 5, 6],
+                     [2, 2, 2]])
+                     
+        expected = (
+        
+            Matrix([[1, 2, 3], 
+                    [6, 7, 8]]),
+                    
+            Matrix([[7, 6, 5], 
+                    [4, 5, 6]]),
+                    
+            Matrix([[2, 2, 2]])
+
+        )
+        
+        self.assertEqual(m1.split_h(3), expected)
+
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The goal of this very simple structure is to offer commonly used functions in D&C such as "splitting" the matrix in pieces. Maybe using `numpy` could be the way to go in the future, but this would require users to be familiar with it, which I'm not sure is a good trade-off at the moment.