### PR TITLE
Set up socket architecture

### DIFF
--- a/src/main/scala/ch/epfl/alcmp/data/InputType.scala
+++ b/src/main/scala/ch/epfl/alcmp/data/InputType.scala
@@ -1,15 +1,31 @@
 package ch.epfl.alcmp.data
 
-sealed trait InputType
+sealed trait InputType {
+  def getType: TypeId
+}
 
-object InputType {
-  trait BinaryTree[T]
-  case class Leaf[T]() extends BinaryTree[T]
-  case class Node[T](value: T, left: BinaryTree[T], right: BinaryTree[T]) extends BinaryTree[T]
+trait BinaryTree[T]
+case class Leaf[T]() extends BinaryTree[T]
+case class Node[T](value: T, left: BinaryTree[T], right: BinaryTree[T]) extends BinaryTree[T]
 
-  type IList = List[Int] with InputType
-  type IMatrix = List[List[Int]] with InputType
-  type IHeap = List[Int] with InputType
-  type IBinaryTree = BinaryTree[Int] with InputType
+
+case class IList(list: List[Int]) extends InputType {
+  override def getType: TypeId = TypeId.ListType
+}
+
+case class IMatrix(rows: List[List[Int]]) extends InputType {
+  override def getType: TypeId = TypeId.MatrixType
+}
+
+case class IHeap(list: List[Int]) extends InputType {
+  override def getType: TypeId = TypeId.HeapType
+}
+
+case class IBinaryTree(root: BinaryTree[Int]) extends InputType {
+  override def getType: TypeId = TypeId.BinaryTreeType
+}
+
+enum TypeId {
+  case ListType, MatrixType, HeapType, BinaryTreeType
 }
 

--- a/src/main/scala/ch/epfl/alcmp/net/MessageId.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/MessageId.scala
@@ -1,0 +1,5 @@
+package ch.epfl.alcmp.net
+
+enum MessageId {
+  case REGISTER, DIVIDE, COMBINE, DONE
+}

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -1,13 +1,12 @@
 package ch.epfl.alcmp.net
 
-import ch.epfl.alcmp.data.InputType
-import ch.epfl.alcmp.data.InputType.{IBinaryTree, IHeap, IList, IMatrix}
-import ch.epfl.alcmp.net.SimulationMessage.{DivideMessage, RegisterMessage}
+import ch.epfl.alcmp.data.{IBinaryTree, IHeap, IList, IMatrix, TypeId}
+import ch.epfl.alcmp.net.SimulationMessage.{CombineMessage, DivideMessage, DoneMessage, RegisterMessage}
 
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
-trait Serde[T] {
+sealed trait Serde[T] {
 
   def serialize(obj: T): String
   def deserialize(data: String): T
@@ -15,38 +14,48 @@ trait Serde[T] {
 
 object Serde {
 
-  val NUMBER: Serde[Int] = new Serde[Int] {
+  given Serde[Int] with
     override def serialize(obj: Int): String = String.valueOf(obj)
-    override def deserialize(data: String): Int = Integer.parseInt(data)
-  }
+    override def deserialize(str: String): Int = Integer.parseInt(str)
 
-  val TEXT: Serde[String] = new Serde[String] {
+  given Serde[String] with
     override def serialize(obj: String): String = Base64.getEncoder.encodeToString(obj.getBytes(StandardCharsets.UTF_8))
     override def deserialize(data: String): String = new String(Base64.getDecoder.decode(data), StandardCharsets.UTF_8)
-  }
 
-  val REGISTER_MESSAGE: Serde[RegisterMessage] = new Serde[RegisterMessage] {
+  given Serde[RegisterMessage] with
     override def serialize(obj: RegisterMessage): String = ???
     override def deserialize(data: String): RegisterMessage = ???
-  }
 
-  val DIVIDE_LIST_MESSAGE: Serde[DivideMessage[IList]] = new Serde[DivideMessage[IList]] {
-    override def serialize(obj: DivideMessage[IList]): String = ???
-    override def deserialize(data: String): DivideMessage[IList] = ???
-  }
 
-  val DIVIDE_MATRIX_MESSAGE: Serde[DivideMessage[IMatrix]] = new Serde[DivideMessage[IMatrix]] {
-    override def serialize(obj: DivideMessage[IMatrix]): String = ???
-    override def deserialize(data: String): DivideMessage[IMatrix] = ???
-  }
+  given Serde[DoneMessage] with
+    override def serialize(obj: DoneMessage): String = ???
+    override def deserialize(data: String): DoneMessage = ???
 
-  val DIVIDE_HEAP_MESSAGE: Serde[DivideMessage[IHeap]] = new Serde[DivideMessage[IHeap]] {
-    override def serialize(obj: DivideMessage[IHeap]): String = ???
-    override def deserialize(data: String): DivideMessage[IHeap] = ???
-  }
+  given (TypeId => Serde[DivideMessage]) with
+    override def apply(t: TypeId): Serde[DivideMessage] = new Serde[DivideMessage]:
+      override def serialize(obj: DivideMessage): String = t match
+        case TypeId.ListType => ???
+        case TypeId.MatrixType => ???
+        case TypeId.HeapType => ???
+        case TypeId.BinaryTreeType => ???
+      override def deserialize(data: String): DivideMessage = t match
+        case TypeId.ListType => ???
+        case TypeId.MatrixType => ???
+        case TypeId.HeapType => ???
+        case TypeId.BinaryTreeType => ???
 
-  val DIVIDE_BINARY_TREE_MESSAGE: Serde[DivideMessage[IBinaryTree]] = new Serde[DivideMessage[IBinaryTree]] {
-    override def serialize(obj: DivideMessage[IBinaryTree]): String = ???
-    override def deserialize(data: String): DivideMessage[IBinaryTree] = ???
-  }
+  given (TypeId => Serde[CombineMessage]) with
+    override def apply(t: TypeId): Serde[CombineMessage] = new Serde[CombineMessage]:
+      override def serialize(obj: CombineMessage): String = obj.output match {
+        case IList(list) => ???
+        case IMatrix(rows) => ???
+        case IHeap(list) => ???
+        case IBinaryTree(root) => ???
+      }
+      override def deserialize(data: String): CombineMessage = t match
+        case TypeId.ListType => ???
+        case TypeId.MatrixType => ???
+        case TypeId.HeapType => ???
+        case TypeId.BinaryTreeType => ???
+
 }

--- a/src/main/scala/ch/epfl/alcmp/net/Serdes.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serdes.scala
@@ -1,0 +1,12 @@
+package ch.epfl.alcmp.net
+
+import ch.epfl.alcmp.data.TypeId
+
+object Serdes {
+  def serialize[T](using serde: Serde[T])(obj: T): String = serde.serialize(obj)
+  def deserialize[T](using serde: Serde[T])(data: String): T = serde.deserialize(data)
+  def serialize[T](using serdeFun: TypeId => Serde[T])(typeId: TypeId, obj: T): String =
+    serdeFun.apply(typeId).serialize(obj)
+  def deserialize[T](using serdeFun: TypeId => Serde[T])(typeId: TypeId, data: String): T =
+    serdeFun.apply(typeId).deserialize(data)
+}

--- a/src/main/scala/ch/epfl/alcmp/net/SimulationListener.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/SimulationListener.scala
@@ -1,0 +1,33 @@
+package ch.epfl.alcmp.net
+
+
+import ch.epfl.alcmp.data.{InputType, TypeId}
+import ch.epfl.alcmp.net.SimulationMessage.{CombineMessage, DivideMessage, DoneMessage, RegisterMessage}
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.util.regex.Pattern
+
+class SimulationListener(private val socket: Socket, private val typeId: TypeId) {
+
+  def run(): Unit =
+
+    val inputStream = socket.getInputStream
+    val reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.US_ASCII))
+
+    def handleOne(): Unit =
+      val args = reader.readLine().split(Pattern.quote(" "), -1)
+      val content = args(1)
+      MessageId.valueOf(args(0)) match {
+        case MessageId.REGISTER => handleRegister(Serdes.deserialize[RegisterMessage](content))
+        case MessageId.DONE     => handleDone(Serdes.deserialize[DoneMessage](content))
+        case MessageId.COMBINE  => handleCombine(Serdes.deserialize[CombineMessage](typeId, content))
+        case MessageId.DIVIDE   => handleDivide(Serdes.deserialize[DivideMessage](typeId, content))
+      }
+
+  def handleRegister(message: RegisterMessage): Unit = ???
+  def handleDone(message: DoneMessage): Unit = ???
+  def handleDivide(message: DivideMessage): Unit = ???
+  def handleCombine(message: CombineMessage): Unit = ???
+}

--- a/src/main/scala/ch/epfl/alcmp/net/SimulationMessage.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/SimulationMessage.scala
@@ -1,6 +1,6 @@
 package ch.epfl.alcmp.net
 
-import ch.epfl.alcmp.data.InputType
+import ch.epfl.alcmp.data.{InputType, TypeId}
 
 sealed trait SimulationMessage {
   def id: Int
@@ -9,8 +9,8 @@ sealed trait SimulationMessage {
 object SimulationMessage {
 
   case class RegisterMessage(id: Int) extends SimulationMessage
-  case class CombineMessage[T <: InputType](id: Int, depth: Int, index: Int, output: T, highlights: List[Int]) extends SimulationMessage
-  case class DivideMessage[T <: InputType](id: Int, depth: Int, index: Int, outputs: List[T], highlights: List[Int]) extends SimulationMessage
+  case class CombineMessage(id: Int, depth: Int, index: Int, output: InputType, highlights: List[Int]) extends SimulationMessage
+  case class DivideMessage(id: Int, depth: Int, index: Int, outputs: List[InputType], highlights: List[Int]) extends SimulationMessage
   case class DoneMessage(id: Int) extends SimulationMessage
 }
 

--- a/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
@@ -9,17 +9,17 @@ class SerdeTest extends AnyFlatSpec with should.Matchers {
 
   "Serializing and Deserializing numbers" should "work" in {
     val n = 456
-    Serde.NUMBER.serialize(n) should be ("456")
+    Serdes.serialize[Int](n) should be ("456")
 
     val random = new Random()
     for i <- 0 to 100 do {
       val r = random.nextInt()
-      Serde.NUMBER.deserialize(Serde.NUMBER.serialize(r)) should be (r)
+      Serdes.deserialize[Int](Serdes.serialize[Int](r)) should be (r)
     }
   }
 
   "Deserializing a serialized text" should "give back the original text" in {
     val text = "Hello, World!"
-    Serde.TEXT.deserialize(Serde.TEXT.serialize(text)) should be (text)
+    Serdes.deserialize[String](Serdes.serialize[String](text)) should be (text)
   }
 }

--- a/src/test/scala/ch/epfl/alcmp/scripting/DCAssemblerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/scripting/DCAssemblerTest.scala
@@ -26,6 +26,9 @@ class DCAssemblerTest extends AnyFlatSpec with should.Matchers {
     val assembly = DCAssembler.assembleUserFunctions("return n == 1", "return arg[0:n//2], arg[n//2:n]", "return arg0 + arg1")
     val expected = read("assembly_example.txt")
 
+    println(assembly)
+    println("-----")
+    println(expected)
     assembly should be (expected)
   }*/
 


### PR DESCRIPTION
A few changes had to be made for the socket to be able to work properly. Instead of having generic `combine` and `divide` messages, they always get a general `InputType` that can be easily pattern-matched thanks to case classes and the new `TypeId` enum that tells the deserializer in what object to transform the `String` it receives. 

Type aliases were, in the end, not very convenient for the task they needed to fulfill, so I used case classes instead.

Messages will be of the form `<MessageId> <MessageContent>` so we also need `Serde`s for `MessageId`s, as well as a general-purpose `Serde` for "union" of two `Serde`s.