### PR TITLE
Add serialization/deserialization for message objects

### DIFF
--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -23,6 +23,10 @@ object Serde {
     override def serialize(obj: String): String = Base64.getEncoder.encodeToString(obj.getBytes(StandardCharsets.UTF_8))
     override def deserialize(data: String): String = new String(Base64.getDecoder.decode(data), StandardCharsets.UTF_8)
 
+  given Serde[List[Int]] with
+    override def serialize(obj: List[Int]): String = listOf[Int](",").serialize(obj)
+    override def deserialize(data: String): List[Int] = listOf[Int](",").deserialize(data)
+
   given Serde[RegisterMessage] with
     override def serialize(obj: RegisterMessage): String = Serdes.serialize[Int](obj.id)
     override def deserialize(data: String): RegisterMessage = RegisterMessage(Serdes.deserialize[Int](data))
@@ -36,19 +40,16 @@ object Serde {
     override def deserialize(data: String): List[T] = data.split(sep).toList.map(elem => Serdes.deserialize[T](elem))
 
   given Serde[IList] with
-    override def serialize(obj: IList): String = listOf[Int](",").serialize(obj.list)
-    override def deserialize(data: String): IList = IList(listOf[Int](",").deserialize(data))
+    override def serialize(obj: IList): String = Serdes.serialize[List[Int]](obj.list)
+    override def deserialize(data: String): IList = IList(Serdes.deserialize[List[Int]](data))
 
   given Serde[IHeap] with
-    override def serialize(obj: IHeap): String = listOf[Int](",").serialize(obj.list)
-    override def deserialize(data: String): IHeap = IHeap(listOf[Int](",").deserialize(data))
+    override def serialize(obj: IHeap): String = Serdes.serialize[List[Int]](obj.list)
+    override def deserialize(data: String): IHeap = IHeap(Serdes.deserialize[List[Int]](data))
 
   given Serde[IMatrix] with
-    override def serialize(obj: IMatrix): String =
-      val b = StringJoiner(",,")
-      obj.rows.foreach(list => b.add(listOf[Int](",").serialize(list)))
-      b.toString
-    override def deserialize(data: String): IMatrix = IMatrix(data.split(",,").toList.map(s => listOf[Int](",").deserialize(s)))
+    override def serialize(obj: IMatrix): String = listOf[List[Int]](",,").serialize(obj.rows)
+    override def deserialize(data: String): IMatrix = IMatrix(listOf[List[Int]](",,").deserialize(data))
 
   given (TypeId => Serde[DivideMessage]) with
     override def apply(t: TypeId): Serde[DivideMessage] = new Serde[DivideMessage]:

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -23,8 +23,8 @@ object Serde {
     override def deserialize(data: String): String = new String(Base64.getDecoder.decode(data), StandardCharsets.UTF_8)
 
   given Serde[RegisterMessage] with
-    override def serialize(obj: RegisterMessage): String = ???
-    override def deserialize(data: String): RegisterMessage = ???
+    override def serialize(obj: RegisterMessage): String = Serdes.serialize[Int](obj.id)
+    override def deserialize(data: String): RegisterMessage = new RegisterMessage(Serdes.deserialize[Int](data))
 
 
   given Serde[DoneMessage] with

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -22,6 +22,9 @@ object Serde {
     override def serialize(obj: String): String = Base64.getEncoder.encodeToString(obj.getBytes(StandardCharsets.UTF_8))
     override def deserialize(data: String): String = new String(Base64.getDecoder.decode(data), StandardCharsets.UTF_8)
 
+  //given Serde[List[]] with
+
+
   given Serde[RegisterMessage] with
     override def serialize(obj: RegisterMessage): String = Serdes.serialize[Int](obj.id)
     override def deserialize(data: String): RegisterMessage = RegisterMessage(Serdes.deserialize[Int](data))
@@ -47,13 +50,19 @@ object Serde {
   given (TypeId => Serde[CombineMessage]) with
     override def apply(t: TypeId): Serde[CombineMessage] = new Serde[CombineMessage]:
       override def serialize(obj: CombineMessage): String = obj.output match {
-        case IList(list) => ???
+        //TODO change
+        case IList(list) => String.valueOf(obj.id) + '/' + String.valueOf(obj.depth) + '/' +
+          String.valueOf(obj.index) + '/' + list.mkString(",") + '/' + obj.highlights.mkString(",")
         case IMatrix(rows) => ???
         case IHeap(list) => ???
         case IBinaryTree(root) => ???
       }
       override def deserialize(data: String): CombineMessage = t match
-        case TypeId.ListType => ???
+        case TypeId.ListType =>
+          val arr = data.split("/")
+          val ilist = arr(3).split(",").map(s => s.toInt)
+          val highlights = arr(4).split(",").map(s => s.toInt)
+          CombineMessage(arr(0).toInt, arr(1).toInt, arr(2).toInt, IList(ilist.toList), highlights.toList)
         case TypeId.MatrixType => ???
         case TypeId.HeapType => ???
         case TypeId.BinaryTreeType => ???

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -28,8 +28,6 @@ object Serde {
     override def serialize(obj: RegisterMessage): String = Serdes.serialize[Int](obj.id)
     override def deserialize(data: String): RegisterMessage = RegisterMessage(Serdes.deserialize[Int](data))
 
-  //given Serde[List[String]]
-
   given Serde[DoneMessage] with
     override def serialize(obj: DoneMessage): String = Serdes.serialize[Int](obj.id)
     override def deserialize(data: String): DoneMessage = DoneMessage(Serdes.deserialize[Int](data))
@@ -72,7 +70,6 @@ object Serde {
         case TypeId.MatrixType =>
           val output = arr(4).substring(2, arr(4).length - 2).split("\\),\\(")
             .map(s => s.split(",").map(s => s.toInt).toList)
-          print(output)
           CombineMessage(arr(0).toInt, arr(1).toInt, arr(2).toInt, IMatrix(output.toList), highlights.toList)
         case TypeId.HeapType =>
           val iheap = arr(4).substring(1, arr(4).length - 1).split(",").map(s => s.toInt)

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -24,12 +24,12 @@ object Serde {
 
   given Serde[RegisterMessage] with
     override def serialize(obj: RegisterMessage): String = Serdes.serialize[Int](obj.id)
-    override def deserialize(data: String): RegisterMessage = new RegisterMessage(Serdes.deserialize[Int](data))
+    override def deserialize(data: String): RegisterMessage = RegisterMessage(Serdes.deserialize[Int](data))
 
 
   given Serde[DoneMessage] with
     override def serialize(obj: DoneMessage): String = Serdes.serialize[Int](obj.id)
-    override def deserialize(data: String): DoneMessage = new DoneMessage(Serdes.deserialize[Int](data))
+    override def deserialize(data: String): DoneMessage = DoneMessage(Serdes.deserialize[Int](data))
 
   given (TypeId => Serde[DivideMessage]) with
     override def apply(t: TypeId): Serde[DivideMessage] = new Serde[DivideMessage]:

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -28,8 +28,8 @@ object Serde {
 
 
   given Serde[DoneMessage] with
-    override def serialize(obj: DoneMessage): String = ???
-    override def deserialize(data: String): DoneMessage = ???
+    override def serialize(obj: DoneMessage): String = Serdes.serialize[Int](obj.id)
+    override def deserialize(data: String): DoneMessage = new DoneMessage(Serdes.deserialize[Int](data))
 
   given (TypeId => Serde[DivideMessage]) with
     override def apply(t: TypeId): Serde[DivideMessage] = new Serde[DivideMessage]:

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -2,9 +2,10 @@ package ch.epfl.alcmp.net
 
 import ch.epfl.alcmp.data.{IBinaryTree, IHeap, IList, IMatrix, TypeId}
 import ch.epfl.alcmp.net.SimulationMessage.{CombineMessage, DivideMessage, DoneMessage, RegisterMessage}
+import jdk.internal.joptsimple.internal.Strings
 
 import java.nio.charset.StandardCharsets
-import java.util.Base64
+import java.util.{Base64, StringJoiner}
 
 sealed trait Serde[T] {
 
@@ -22,13 +23,12 @@ object Serde {
     override def serialize(obj: String): String = Base64.getEncoder.encodeToString(obj.getBytes(StandardCharsets.UTF_8))
     override def deserialize(data: String): String = new String(Base64.getDecoder.decode(data), StandardCharsets.UTF_8)
 
-  //given Serde[List[]] with
-
 
   given Serde[RegisterMessage] with
     override def serialize(obj: RegisterMessage): String = Serdes.serialize[Int](obj.id)
     override def deserialize(data: String): RegisterMessage = RegisterMessage(Serdes.deserialize[Int](data))
 
+  //given Serde[List[String]]
 
   given Serde[DoneMessage] with
     override def serialize(obj: DoneMessage): String = Serdes.serialize[Int](obj.id)
@@ -36,7 +36,9 @@ object Serde {
 
   given (TypeId => Serde[DivideMessage]) with
     override def apply(t: TypeId): Serde[DivideMessage] = new Serde[DivideMessage]:
-      override def serialize(obj: DivideMessage): String = t match
+      override def serialize(obj: DivideMessage): String =
+        val commonPart = List(obj.id, obj.depth, obj.index, obj.highlights.mkString("(", ",", ")")).mkString("/")
+        t match
         case TypeId.ListType => ???
         case TypeId.MatrixType => ???
         case TypeId.HeapType => ???
@@ -49,22 +51,31 @@ object Serde {
 
   given (TypeId => Serde[CombineMessage]) with
     override def apply(t: TypeId): Serde[CombineMessage] = new Serde[CombineMessage]:
-      override def serialize(obj: CombineMessage): String = obj.output match {
-        //TODO change
-        case IList(list) => String.valueOf(obj.id) + '/' + String.valueOf(obj.depth) + '/' +
-          String.valueOf(obj.index) + '/' + list.mkString(",") + '/' + obj.highlights.mkString(",")
-        case IMatrix(rows) => ???
-        case IHeap(list) => ???
+      override def serialize(obj: CombineMessage): String =
+        val commonPart = List(obj.id, obj.depth, obj.index, obj.highlights.mkString("(", ",", ")")).mkString("/")
+        obj.output match {
+        case IList(list) => commonPart + '/' + list.mkString("(", ",", ")")
+        case IMatrix(rows) =>
+          val b = new StringJoiner(",", "(", ")")
+          rows.foreach(list => b.add(list.mkString("(", ",", ")")))
+          commonPart + '/' + b.toString
+        case IHeap(list) => commonPart + '/' + list.mkString("(", ",", ")")
         case IBinaryTree(root) => ???
       }
-      override def deserialize(data: String): CombineMessage = t match
+      override def deserialize(data: String): CombineMessage =
+        val arr = data.split("/")
+        val highlights = arr(3).substring(1, arr(3).length - 1).split(",").map(s => s.toInt)
+        t match
         case TypeId.ListType =>
-          val arr = data.split("/")
-          val ilist = arr(3).split(",").map(s => s.toInt)
-          val highlights = arr(4).split(",").map(s => s.toInt)
-          CombineMessage(arr(0).toInt, arr(1).toInt, arr(2).toInt, IList(ilist.toList), highlights.toList)
-        case TypeId.MatrixType => ???
-        case TypeId.HeapType => ???
+          val output = arr(4).substring(1, arr(4).length - 1).split(",").map(s => s.toInt)
+          CombineMessage(arr(0).toInt, arr(1).toInt, arr(2).toInt, IList(output.toList), highlights.toList)
+        case TypeId.MatrixType =>
+          val output = arr(4).substring(2, arr(4).length - 2).split("\\),\\(")
+            .map(s => s.split(",").map(s => s.toInt).toList)
+          print(output)
+          CombineMessage(arr(0).toInt, arr(1).toInt, arr(2).toInt, IMatrix(output.toList), highlights.toList)
+        case TypeId.HeapType =>
+          val iheap = arr(4).substring(1, arr(4).length - 1).split(",").map(s => s.toInt)
+          CombineMessage(arr(0).toInt, arr(1).toInt, arr(2).toInt, IHeap(iheap.toList), highlights.toList)
         case TypeId.BinaryTreeType => ???
-
 }

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -75,17 +75,12 @@ object Serde {
         val arr = data.split("/")
         val (id, depth, index) = (Serdes.deserialize[Int](arr(0)), Serdes.deserialize[Int](arr(1)), Serdes.deserialize[Int](arr(2)))
         val highlights = listOf[Int](",").deserialize(arr(3))
-        t match
-        case TypeId.ListType =>
-          val outputs = listOf[IList](";").deserialize(arr(4))
-          DivideMessage(id, depth, index, outputs, highlights)
-        case TypeId.MatrixType =>
-          val outputs = listOf[IMatrix](";").deserialize(arr(4))
-          DivideMessage(id, depth, index, outputs, highlights)
-        case TypeId.HeapType =>
-          val outputs = listOf[IHeap](";").deserialize(arr(4))
-          DivideMessage(id, depth, index, outputs, highlights)
-        case TypeId.BinaryTreeType => ???
+        val outputs = t match
+          case TypeId.ListType => listOf[IList](";").deserialize(arr(4))
+          case TypeId.MatrixType => listOf[IMatrix](";").deserialize(arr(4))
+          case TypeId.HeapType => listOf[IHeap](";").deserialize(arr(4))
+          case TypeId.BinaryTreeType => ???
+        DivideMessage(id, depth, index, outputs, highlights)
 
   given (TypeId => Serde[CombineMessage]) with
     override def apply(t: TypeId): Serde[CombineMessage] = new Serde[CombineMessage]:
@@ -95,20 +90,21 @@ object Serde {
           .add(obj.depth.toString)
           .add(obj.index.toString)
           .add(listOf[Int](",").serialize(obj.highlights))
-        obj.output match {
+        obj.output match
           case ilist: IList => b1.add(Serdes.serialize[IList](ilist))
           case imatrix: IMatrix => b1.add(Serdes.serialize[IMatrix](imatrix))
           case iheap: IHeap => b1.add(Serdes.serialize[IHeap](iheap))
           case ibinary: IBinaryTree => ???
-        }
+
         b1.toString
       override def deserialize(data: String): CombineMessage =
         val arr = data.split("/")
         val (id, depth, index) = (Serdes.deserialize[Int](arr(0)), Serdes.deserialize[Int](arr(1)), Serdes.deserialize[Int](arr(2)))
         val highlights = listOf[Int](",").deserialize(arr(3))
-        t match
-        case TypeId.ListType => CombineMessage(id, depth, index, Serdes.deserialize[IList](arr(4)), highlights)
-        case TypeId.MatrixType => CombineMessage(id, depth, index, Serdes.deserialize[IMatrix](arr(4)), highlights)
-        case TypeId.HeapType => CombineMessage(id, depth, index,Serdes.deserialize[IHeap](arr(4)), highlights)
-        case TypeId.BinaryTreeType => ???
+        val output = t match
+          case TypeId.ListType => Serdes.deserialize[IList](arr(4))
+          case TypeId.MatrixType => Serdes.deserialize[IMatrix](arr(4))
+          case TypeId.HeapType => Serdes.deserialize[IHeap](arr(4))
+          case TypeId.BinaryTreeType => ???
+        CombineMessage(id, depth, index, output, highlights)
 }

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -107,7 +107,7 @@ object Serde {
           val output = arr(4).split(",,").toList.map(s => listOf[Int](",").deserialize(s))
           CombineMessage(id, depth, index, IMatrix(output), highlights)
         case TypeId.HeapType =>
-          val output = listOf[Int](",").deserialize(arr(3))
+          val output = listOf[Int](",").deserialize(arr(4))
           CombineMessage(id, depth, index, IHeap(output), highlights)
         case TypeId.BinaryTreeType => ???
 }

--- a/src/main/scala/ch/epfl/alcmp/net/Serde.scala
+++ b/src/main/scala/ch/epfl/alcmp/net/Serde.scala
@@ -2,7 +2,6 @@ package ch.epfl.alcmp.net
 
 import ch.epfl.alcmp.data.{IBinaryTree, IHeap, IList, IMatrix, InputType, TypeId}
 import ch.epfl.alcmp.net.SimulationMessage.{CombineMessage, DivideMessage, DoneMessage, RegisterMessage}
-import jdk.internal.joptsimple.internal.Strings
 
 import java.nio.charset.StandardCharsets
 import java.util.{Base64, StringJoiner}
@@ -35,7 +34,7 @@ object Serde {
   given (TypeId => Serde[DivideMessage]) with
     override def apply(t: TypeId): Serde[DivideMessage] = new Serde[DivideMessage]:
       override def serialize(obj: DivideMessage): String =
-        var s = List(obj.id, obj.depth, obj.index, obj.highlights.mkString(",")).mkString("/") + "/"
+        val s = List(obj.id, obj.depth, obj.index, obj.highlights.mkString(",")).mkString("/") + "/"
         val b1 = StringJoiner(";")
         for ( output <- obj.outputs) {
           output match

--- a/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
@@ -1,5 +1,7 @@
 package ch.epfl.alcmp.net
 
+import ch.epfl.alcmp.data.IList
+import ch.epfl.alcmp.data.TypeId
 import ch.epfl.alcmp.net.SimulationMessage.{CombineMessage, DivideMessage, DoneMessage, RegisterMessage}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
@@ -25,14 +27,24 @@ class SerdeTest extends AnyFlatSpec with should.Matchers {
   }
 
   "Serializing and Deserializing REGISTER messages" should "work" in {
-    val reg1 = new RegisterMessage(57)
+    val reg1 = RegisterMessage(57)
     Serdes.serialize[RegisterMessage](reg1) should be ("57")
     Serdes.deserialize[RegisterMessage]("68") should be (RegisterMessage(68))
   }
 
   "Serializing and Deserializing DONE messages" should "work" in {
-    val reg1 = new DoneMessage(57456)
+    val reg1 = DoneMessage(57456)
     Serdes.serialize[DoneMessage](reg1) should be ("57456")
     Serdes.deserialize[DoneMessage]("68") should be (DoneMessage(68))
+  }
+
+  "Serializing and Deserializing COMBINE messages" should "work" in {
+    val reg1 = CombineMessage(101, 2, 1, IList(List(5, 6, 7)), List(0, 1, 2))
+    val reg2 = CombineMessage(102, 3, 2, IList(List(6, 7, 8)), List(1, 2, 3))
+    Serdes.serialize[CombineMessage](TypeId.ListType, reg1) should be ("101/2/1/5,6,7/0,1,2")
+    Serdes.serialize[CombineMessage](TypeId.ListType, reg2) should be ("102/3/2/6,7,8/1,2,3")
+    Serdes.deserialize[CombineMessage](TypeId.ListType, "1/2/3/0,9,10/0,1,2") should be (CombineMessage(1, 2, 3, IList(List(0, 9, 10)), List(0, 1, 2)))
+    Serdes.deserialize[CombineMessage](TypeId.ListType, "0/0/0/0,0,0/0,0,0") should be (CombineMessage(0, 0, 0, IList(List(0, 0, 0)), List(0, 0, 0)))
+
   }
 }

--- a/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
@@ -27,12 +27,12 @@ class SerdeTest extends AnyFlatSpec with should.Matchers {
   "Serializing and Deserializing REGISTER messages" should "work" in {
     val reg1 = new RegisterMessage(57)
     Serdes.serialize[RegisterMessage](reg1) should be ("57")
-    Serdes.deserialize[RegisterMessage]("68") should be (new RegisterMessage(68))
+    Serdes.deserialize[RegisterMessage]("68") should be (RegisterMessage(68))
   }
 
   "Serializing and Deserializing DONE messages" should "work" in {
     val reg1 = new DoneMessage(57456)
     Serdes.serialize[DoneMessage](reg1) should be ("57456")
-    Serdes.deserialize[DoneMessage]("68") should be (new DoneMessage(68))
+    Serdes.deserialize[DoneMessage]("68") should be (DoneMessage(68))
   }
 }

--- a/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
@@ -1,6 +1,6 @@
 package ch.epfl.alcmp.net
 
-import ch.epfl.alcmp.data.IList
+import ch.epfl.alcmp.data.{IList, IMatrix, IHeap, IBinaryTree}
 import ch.epfl.alcmp.data.TypeId
 import ch.epfl.alcmp.net.SimulationMessage.{CombineMessage, DivideMessage, DoneMessage, RegisterMessage}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -39,12 +39,16 @@ class SerdeTest extends AnyFlatSpec with should.Matchers {
   }
 
   "Serializing and Deserializing COMBINE messages" should "work" in {
-    val reg1 = CombineMessage(101, 2, 1, IList(List(5, 6, 7)), List(0, 1, 2))
-    val reg2 = CombineMessage(102, 3, 2, IList(List(6, 7, 8)), List(1, 2, 3))
-    Serdes.serialize[CombineMessage](TypeId.ListType, reg1) should be ("101/2/1/5,6,7/0,1,2")
-    Serdes.serialize[CombineMessage](TypeId.ListType, reg2) should be ("102/3/2/6,7,8/1,2,3")
-    Serdes.deserialize[CombineMessage](TypeId.ListType, "1/2/3/0,9,10/0,1,2") should be (CombineMessage(1, 2, 3, IList(List(0, 9, 10)), List(0, 1, 2)))
-    Serdes.deserialize[CombineMessage](TypeId.ListType, "0/0/0/0,0,0/0,0,0") should be (CombineMessage(0, 0, 0, IList(List(0, 0, 0)), List(0, 0, 0)))
+    val comb1 = CombineMessage(101, 2, 1, IList(List(5, 6, 7)), List(0, 1, 2))
+    Serdes.serialize[CombineMessage](TypeId.ListType, comb1) should be ("101/2/1/(0,1,2)/(5,6,7)")
+    Serdes.deserialize[CombineMessage](TypeId.ListType, "101/2/1/(0,1,2)/(5,6,7)") should be (comb1)
 
+    val comb2 = CombineMessage(101, 2, 1, IMatrix(List(List(1, 0), List(0, 1))), List(0, 1, 2))
+    Serdes.serialize[CombineMessage](TypeId.MatrixType, comb2) should be ("101/2/1/(0,1,2)/((1,0),(0,1))")
+    Serdes.deserialize[CombineMessage](TypeId.MatrixType, "101/2/1/(0,1,2)/((1,0),(0,1))") should be (comb2)
+
+    val comb3 = CombineMessage(102, 3, 2, IHeap(List(6, 7, 8)), List(1, 2, 3))
+    Serdes.serialize[CombineMessage](TypeId.HeapType, comb3) should be ("102/3/2/(1,2,3)/(6,7,8)")
+    Serdes.deserialize[CombineMessage](TypeId.HeapType, "102/3/2/(1,2,3)/(6,7,8)") should be (comb3)
   }
 }

--- a/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
@@ -40,15 +40,29 @@ class SerdeTest extends AnyFlatSpec with should.Matchers {
 
   "Serializing and Deserializing COMBINE messages" should "work" in {
     val comb1 = CombineMessage(101, 2, 1, IList(List(5, 6, 7)), List(0, 1, 2))
-    Serdes.serialize[CombineMessage](TypeId.ListType, comb1) should be ("101/2/1/(0,1,2)/(5,6,7)")
-    Serdes.deserialize[CombineMessage](TypeId.ListType, "101/2/1/(0,1,2)/(5,6,7)") should be (comb1)
+    Serdes.serialize[CombineMessage](TypeId.ListType, comb1) should be ("101/2/1/0,1,2/5,6,7")
+    Serdes.deserialize[CombineMessage](TypeId.ListType, "101/2/1/0,1,2/5,6,7") should be (comb1)
 
     val comb2 = CombineMessage(101, 2, 1, IMatrix(List(List(1, 0), List(0, 1))), List(0, 1, 2))
-    Serdes.serialize[CombineMessage](TypeId.MatrixType, comb2) should be ("101/2/1/(0,1,2)/((1,0),(0,1))")
-    Serdes.deserialize[CombineMessage](TypeId.MatrixType, "101/2/1/(0,1,2)/((1,0),(0,1))") should be (comb2)
+    Serdes.serialize[CombineMessage](TypeId.MatrixType, comb2) should be ("101/2/1/0,1,2/1,0,,0,1")
+    Serdes.deserialize[CombineMessage](TypeId.MatrixType, "101/2/1/0,1,2/1,0,,0,1") should be (comb2)
 
     val comb3 = CombineMessage(102, 3, 2, IHeap(List(6, 7, 8)), List(1, 2, 3))
-    Serdes.serialize[CombineMessage](TypeId.HeapType, comb3) should be ("102/3/2/(1,2,3)/(6,7,8)")
-    Serdes.deserialize[CombineMessage](TypeId.HeapType, "102/3/2/(1,2,3)/(6,7,8)") should be (comb3)
+    Serdes.serialize[CombineMessage](TypeId.HeapType, comb3) should be ("102/3/2/1,2,3/6,7,8")
+    Serdes.deserialize[CombineMessage](TypeId.HeapType, "102/3/2/1,2,3/6,7,8") should be (comb3)
+  }
+
+  "Serializing and Deserializing DIVIDE messages" should "work" in {
+    val div1 = DivideMessage(101, 2, 1, List(IList(List(5, 6, 7)), IList(List(2,5,2))), List(0, 1, 2))
+    Serdes.serialize[DivideMessage](TypeId.ListType, div1) should be ("101/2/1/0,1,2/5,6,7;2,5,2")
+    Serdes.deserialize[DivideMessage](TypeId.ListType, "101/2/1/0,1,2/5,6,7;2,5,2") should be (div1)
+
+    val div2 = DivideMessage(101, 2, 1, List(IMatrix(List(List(1, 0), List(0, 1))), IMatrix(List(List(2, 0), List(0, 2)))), List(0, 1, 2))
+    Serdes.serialize[DivideMessage](TypeId.MatrixType, div2) should be ("101/2/1/0,1,2/1,0,,0,1;2,0,,0,2")
+    Serdes.deserialize[DivideMessage](TypeId.MatrixType, "101/2/1/0,1,2/1,0,,0,1;2,0,,0,2") should be (div2)
+
+    val div3 = DivideMessage(102, 3, 2, List(IHeap(List(6, 7, 8)), IHeap(List(1,2,3))), List(1, 2, 3))
+    Serdes.serialize[DivideMessage](TypeId.HeapType, div3) should be ("102/3/2/1,2,3/6,7,8;1,2,3")
+    Serdes.deserialize[DivideMessage](TypeId.HeapType, "102/3/2/1,2,3/6,7,8;1,2,3") should be (div3)
   }
 }

--- a/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
@@ -1,6 +1,6 @@
 package ch.epfl.alcmp.net
 
-import ch.epfl.alcmp.net.SimulationMessage.RegisterMessage
+import ch.epfl.alcmp.net.SimulationMessage.{CombineMessage, DivideMessage, DoneMessage, RegisterMessage}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
@@ -28,5 +28,11 @@ class SerdeTest extends AnyFlatSpec with should.Matchers {
     val reg1 = new RegisterMessage(57)
     Serdes.serialize[RegisterMessage](reg1) should be ("57")
     Serdes.deserialize[RegisterMessage]("68") should be (new RegisterMessage(68))
+  }
+
+  "Serializing and Deserializing DONE messages" should "work" in {
+    val reg1 = new DoneMessage(57456)
+    Serdes.serialize[DoneMessage](reg1) should be ("57456")
+    Serdes.deserialize[DoneMessage]("68") should be (new DoneMessage(68))
   }
 }

--- a/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/net/SerdeTest.scala
@@ -1,5 +1,6 @@
 package ch.epfl.alcmp.net
 
+import ch.epfl.alcmp.net.SimulationMessage.RegisterMessage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
@@ -21,5 +22,11 @@ class SerdeTest extends AnyFlatSpec with should.Matchers {
   "Deserializing a serialized text" should "give back the original text" in {
     val text = "Hello, World!"
     Serdes.deserialize[String](Serdes.serialize[String](text)) should be (text)
+  }
+
+  "Serializing and Deserializing REGISTER messages" should "work" in {
+    val reg1 = new RegisterMessage(57)
+    Serdes.serialize[RegisterMessage](reg1) should be ("57")
+    Serdes.deserialize[RegisterMessage]("68") should be (new RegisterMessage(68))
   }
 }


### PR DESCRIPTION
Some implementation decisions have changed from #5 . Instead of having to deal with annoying imbricated parantheses for lists of lists, we simply use a different seperators to represent different levels of imbrication. 

For example in a COMBINE message with the output of type matrix` ((1, 0), (0,1))` it would become `"1,0,,0,1"`.  This is then easily deserialised using the split function.
DIVIDE messages work similarly. since the outputs are `List[InputType]` we add the extra seperator `;`.
`(((1, 0), (0,1)), ((2, 1), (1, 2)))` becomes `"1,0,,0,1;2,1,,1,2"`.