### PR TITLE
Add visualizer for lists and paths

### DIFF
--- a/src/main/resources/css/vis-list.css
+++ b/src/main/resources/css/vis-list.css
@@ -5,5 +5,4 @@
     -fx-border-radius: 10 10 10 10;
     -fx-background-radius: 10 10 10 10;
     -fx-background-color: #EED6C7;
-    -fx-opacity: 0;
 }

--- a/src/main/resources/css/vis-list.css
+++ b/src/main/resources/css/vis-list.css
@@ -5,4 +5,5 @@
     -fx-border-radius: 10 10 10 10;
     -fx-background-radius: 10 10 10 10;
     -fx-background-color: #EED6C7;
+    -fx-opacity: 0;
 }

--- a/src/main/resources/css/vis-list.css
+++ b/src/main/resources/css/vis-list.css
@@ -1,0 +1,8 @@
+.number {
+    -fx-alignment: center;
+    -fx-font-size: 20pt;
+    -fx-font-family: "Cambria";
+    -fx-border-radius: 10 10 10 10;
+    -fx-background-radius: 10 10 10 10;
+    -fx-background-color: #EED6C7;
+}

--- a/src/main/scala/ch/epfl/alcmp/data/BinaryTree.scala
+++ b/src/main/scala/ch/epfl/alcmp/data/BinaryTree.scala
@@ -1,0 +1,6 @@
+package ch.epfl.alcmp.data
+
+sealed trait BinaryTree[T]
+
+case class Leaf[T]() extends BinaryTree[T]
+case class Node[T](value: T, left: BinaryTree[T], right: BinaryTree[T]) extends BinaryTree[T]

--- a/src/main/scala/ch/epfl/alcmp/data/InputType.scala
+++ b/src/main/scala/ch/epfl/alcmp/data/InputType.scala
@@ -4,11 +4,6 @@ sealed trait InputType {
   def getType: TypeId
 }
 
-trait BinaryTree[T]
-case class Leaf[T]() extends BinaryTree[T]
-case class Node[T](value: T, left: BinaryTree[T], right: BinaryTree[T]) extends BinaryTree[T]
-
-
 case class IList(list: List[Int]) extends InputType {
   override def getType: TypeId = TypeId.ListType
 }

--- a/src/main/scala/ch/epfl/alcmp/gui/CompositeVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/CompositeVisualizer.scala
@@ -1,0 +1,41 @@
+package ch.epfl.alcmp.gui
+
+import javafx.animation.{Animation, Transition}
+import javafx.scene.layout.Pane
+import javafx.scene.Node
+import javafx.util.Duration
+
+object CompositeVisualizer {
+
+  def drawWithPath[T <: Visualizable](using v1: Visualizer[T])
+                                     (pane: Pane, top: T, links: List[T], topPos: Position, linksPos: List[Position]): Animation =
+
+    // TODO: use CompositeTransition + ParallelTransition instead
+    val animation: Transition = new Transition() {
+      var started = false
+      var reachedThird = false
+      var reachedSecondThird = false
+      val shiftedTopPosition = Position(topPos.x, topPos.y + 60)
+
+      {
+        setCycleDuration(Duration.millis(3000))
+      }
+      override def interpolate(v: Double): Unit =
+        if v >= 0 && !started then
+          started = true
+          v1.visualize(pane, top, topPos)
+        else if v >= 0.33 && !reachedThird then
+          reachedThird = true
+          for (pos <- linksPos) {
+            PathVisualizer.visualize(pane, (shiftedTopPosition, pos), topPos)
+          }
+        else if v >= 0.66 && !reachedSecondThird then
+          reachedSecondThird = true
+          for ((link, linkPos) <- links.zip(linksPos)) {
+            v1.visualize(pane, link, linkPos)
+          }
+    }
+
+    animation.play()
+    animation
+}

--- a/src/main/scala/ch/epfl/alcmp/gui/CompositeVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/CompositeVisualizer.scala
@@ -13,10 +13,10 @@ object CompositeVisualizer {
 
     val anim1 = v1.visualize(pane, top, topPos)
 
-    val shiftedTopPosition = Position(topPos.x, topPos.y + 60)
+    val shiftedTopPosition = Position(topPos.x, topPos.y + shiftFor(top))
     val anim2 = ParallelTransition()
     for (pos <- linksPos) {
-      anim2.getChildren.add(PathVisualizer.visualize(pane, (shiftedTopPosition, pos), topPos))
+      anim2.getChildren.add(Visualizer.visualize[VisualizableLine](pane, (shiftedTopPosition, pos), topPos))
     }
 
     val anim3 = SequentialTransition()
@@ -26,4 +26,10 @@ object CompositeVisualizer {
 
     val fullAnimation = SequentialTransition(anim1, anim2, anim3)
     fullAnimation
+
+  private def shiftFor(v: Visualizable): Int = v match {
+    case VisualizableList(_) => 60
+    case VisualizableLine(_, _) => 0
+    case _ => 0
+  }
 }

--- a/src/main/scala/ch/epfl/alcmp/gui/CompositeVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/CompositeVisualizer.scala
@@ -1,6 +1,6 @@
 package ch.epfl.alcmp.gui
 
-import javafx.animation.{Animation, Transition}
+import javafx.animation.{Animation, ParallelTransition, SequentialTransition, Transition}
 import javafx.scene.layout.Pane
 import javafx.scene.Node
 import javafx.util.Duration
@@ -10,32 +10,20 @@ object CompositeVisualizer {
   def drawWithPath[T <: Visualizable](using v1: Visualizer[T])
                                      (pane: Pane, top: T, links: List[T], topPos: Position, linksPos: List[Position]): Animation =
 
-    // TODO: use CompositeTransition + ParallelTransition instead
-    val animation: Transition = new Transition() {
-      var started = false
-      var reachedThird = false
-      var reachedSecondThird = false
-      val shiftedTopPosition = Position(topPos.x, topPos.y + 60)
+    val anim1 = v1.visualize(pane, top, topPos)
 
-      {
-        setCycleDuration(Duration.millis(3000))
-      }
-      override def interpolate(v: Double): Unit =
-        if v >= 0 && !started then
-          started = true
-          v1.visualize(pane, top, topPos)
-        else if v >= 0.33 && !reachedThird then
-          reachedThird = true
-          for (pos <- linksPos) {
-            PathVisualizer.visualize(pane, (shiftedTopPosition, pos), topPos)
-          }
-        else if v >= 0.66 && !reachedSecondThird then
-          reachedSecondThird = true
-          for ((link, linkPos) <- links.zip(linksPos)) {
-            v1.visualize(pane, link, linkPos)
-          }
+    val shiftedTopPosition = Position(topPos.x, topPos.y + 60)
+    val anim2 = ParallelTransition()
+    for (pos <- linksPos) {
+      anim2.getChildren.add(PathVisualizer.visualize(pane, (shiftedTopPosition, pos), topPos))
     }
 
-    animation.play()
-    animation
+    val anim3 = SequentialTransition()
+    for ((link, linkPos) <- links.zip(linksPos)) {
+      anim3.getChildren.add(v1.visualize(pane, link, linkPos))
+    }
+
+    val fullAnimation = SequentialTransition(anim1, anim2, anim3)
+    fullAnimation.play()
+    fullAnimation
 }

--- a/src/main/scala/ch/epfl/alcmp/gui/CompositeVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/CompositeVisualizer.scala
@@ -1,6 +1,6 @@
 package ch.epfl.alcmp.gui
 
-import javafx.animation.{Animation, ParallelTransition, SequentialTransition, Transition}
+import javafx.animation.{Animation, ParallelTransition, PauseTransition, SequentialTransition, Transition}
 import javafx.scene.layout.Pane
 import javafx.scene.Node
 import javafx.util.Duration
@@ -9,6 +9,7 @@ object CompositeVisualizer {
 
   def drawWithPath[T <: Visualizable](using v1: Visualizer[T])
                                      (pane: Pane, top: T, links: List[T], topPos: Position, linksPos: List[Position]): Animation =
+
 
     val anim1 = v1.visualize(pane, top, topPos)
 
@@ -24,6 +25,5 @@ object CompositeVisualizer {
     }
 
     val fullAnimation = SequentialTransition(anim1, anim2, anim3)
-    fullAnimation.play()
     fullAnimation
 }

--- a/src/main/scala/ch/epfl/alcmp/gui/ListVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/ListVisualizer.scala
@@ -22,9 +22,6 @@ object ListVisualizer extends Visualizer[VisualizableList] {
     pane.setOpacity(0)
     pane.getStylesheets.add("css/vis-list.css")
 
-    /*val marker = Circle(5)
-    pane.getChildren.add(marker)*/
-
     var numberIndex = 0
 
     val list = vlist.list
@@ -32,7 +29,7 @@ object ListVisualizer extends Visualizer[VisualizableList] {
       val element = Label(number.toString)
       element.setPrefSize(SIZE, SIZE)
 
-      val xShift = (SIZE + SPACING) * (numberIndex - list.size / 2.0) + SPACING/2
+      val xShift = (SIZE + SPACING) * (numberIndex - list.size / 2.0) + SPACING / 2.0
       numberIndex += 1
 
       element.setTranslateX(xShift)

--- a/src/main/scala/ch/epfl/alcmp/gui/ListVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/ListVisualizer.scala
@@ -3,19 +3,20 @@ package ch.epfl.alcmp.gui
 import javafx.animation.Animation
 import javafx.animation.FadeTransition
 import javafx.geometry.Pos
+import javafx.scene.Node
 import javafx.scene.control.Label
 import javafx.scene.layout.{HBox, Pane}
 import javafx.scene.paint.Color
 import javafx.scene.shape.{Circle, Rectangle}
 import javafx.util.Duration
 
-object ListVisualizer {
+object ListVisualizer extends Visualizer[VisualizableList] {
 
   private val SPACING = 4
   private val ORIGIN_SHIFT = 10
   private val SIZE = 30
 
-  def visualize(parent: Pane, pos: (Int, Int), list: List[Int]): Pane =
+  override def visualize(parent: Pane, vlist: VisualizableList, pos: Position): Animation =
 
     val pane = Pane()
     pane.getStylesheets.add("css/vis-list.css")
@@ -25,6 +26,7 @@ object ListVisualizer {
 
     var numberIndex = 0
 
+    val list = vlist.list
     for (number <- list) {
       val element = Label(number.toString)
       element.setPrefSize(SIZE, SIZE)
@@ -40,7 +42,7 @@ object ListVisualizer {
     }
 
     parent.getChildren.add(pane)
-    pane.relocate(pos._1, pos._2)
+    pane.relocate(pos.x, pos.y)
 
     val ft: FadeTransition = FadeTransition(Duration.millis(1000), pane)
     ft.setFromValue(0.0)
@@ -48,5 +50,5 @@ object ListVisualizer {
     ft.setCycleCount(1)
     ft.play()
 
-    pane
+    ft
 }

--- a/src/main/scala/ch/epfl/alcmp/gui/ListVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/ListVisualizer.scala
@@ -19,6 +19,7 @@ object ListVisualizer extends Visualizer[VisualizableList] {
   override def visualize(parent: Pane, vlist: VisualizableList, pos: Position): Animation =
 
     val pane = Pane()
+    pane.setOpacity(0)
     pane.getStylesheets.add("css/vis-list.css")
 
     /*val marker = Circle(5)
@@ -48,7 +49,6 @@ object ListVisualizer extends Visualizer[VisualizableList] {
     ft.setFromValue(0.0)
     ft.setToValue(1.0)
     ft.setCycleCount(1)
-    ft.play()
 
     ft
 }

--- a/src/main/scala/ch/epfl/alcmp/gui/ListVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/ListVisualizer.scala
@@ -1,0 +1,52 @@
+package ch.epfl.alcmp.gui
+
+import javafx.animation.Animation
+import javafx.animation.FadeTransition
+import javafx.geometry.Pos
+import javafx.scene.control.Label
+import javafx.scene.layout.{HBox, Pane}
+import javafx.scene.paint.Color
+import javafx.scene.shape.{Circle, Rectangle}
+import javafx.util.Duration
+
+object ListVisualizer {
+
+  private val SPACING = 4
+  private val ORIGIN_SHIFT = 10
+  private val SIZE = 30
+
+  def visualize(parent: Pane, pos: (Int, Int), list: List[Int]): Pane =
+
+    val pane = Pane()
+    pane.getStylesheets.add("css/vis-list.css")
+
+    /*val marker = Circle(5)
+    pane.getChildren.add(marker)*/
+
+    var numberIndex = 0
+
+    for (number <- list) {
+      val element = Label(number.toString)
+      element.setPrefSize(SIZE, SIZE)
+
+      val xShift = (SIZE + SPACING) * (numberIndex - list.size / 2.0) + SPACING/2
+      numberIndex += 1
+
+      element.setTranslateX(xShift)
+      element.setTranslateY(ORIGIN_SHIFT)
+
+      element.getStyleClass.add("number")
+      pane.getChildren.add(element)
+    }
+
+    parent.getChildren.add(pane)
+    pane.relocate(pos._1, pos._2)
+
+    val ft: FadeTransition = FadeTransition(Duration.millis(1000), pane)
+    ft.setFromValue(0.0)
+    ft.setToValue(1.0)
+    ft.setCycleCount(1)
+    ft.play()
+
+    pane
+}

--- a/src/main/scala/ch/epfl/alcmp/gui/PathVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/PathVisualizer.scala
@@ -10,6 +10,7 @@ object PathVisualizer extends Visualizer[VisualizableLine] {
   override def visualize(parent: Pane, line: VisualizableLine, pos: Position): Animation =
     val lineObj = Line(line.start.x, line.start.y, line.start.x, line.start.y)
     lineObj.setStrokeWidth(2.5)
+    lineObj.setOpacity(0)
 
     parent.getChildren.add(lineObj)
 
@@ -18,13 +19,12 @@ object PathVisualizer extends Visualizer[VisualizableLine] {
         setCycleDuration(Duration.millis(1000))
       }
       override def interpolate(frac: Double): Unit =
+        lineObj.setOpacity(1)
         val vector = (line.end.x - line.start.x, line.end.y - line.start.y)
         val forward = (frac * vector._1, frac * vector._2)
 
         lineObj.setEndX(line.start.x + forward._1)
         lineObj.setEndY(line.start.y + forward._2)
     }
-
-    animation.play()
     animation
 }

--- a/src/main/scala/ch/epfl/alcmp/gui/PathVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/PathVisualizer.scala
@@ -1,31 +1,30 @@
 package ch.epfl.alcmp.gui
 
-import javafx.animation.Transition
+import javafx.animation.{Animation, Transition}
 import javafx.scene.layout.Pane
 import javafx.scene.shape.Line
 import javafx.util.Duration
 
-object PathVisualizer {
+object PathVisualizer extends Visualizer[VisualizableLine] {
 
-  def visualize(parent: Pane, a: (Int, Int), b: (Int, Int)): Line =
-    val line = Line(a._1, a._2, a._1, a._2)
-    line.setStrokeWidth(2.5)
+  override def visualize(parent: Pane, line: VisualizableLine, pos: Position): Animation =
+    val lineObj = Line(line.start.x, line.start.y, line.start.x, line.start.y)
+    lineObj.setStrokeWidth(2.5)
 
-    parent.getChildren.add(line)
+    parent.getChildren.add(lineObj)
 
     val animation = new Transition() {
       {
         setCycleDuration(Duration.millis(1000))
       }
       override def interpolate(frac: Double): Unit =
-        val vector = (b._1 - a._1, b._2 - a._2)
-        //val finalLength = Math.sqrt((b._2 - a._2)*(b._2 - a._2) + (b._2 - a._2) * (b._2 - a._2))
+        val vector = (line.end.x - line.start.x, line.end.y - line.start.y)
         val forward = (frac * vector._1, frac * vector._2)
 
-        line.setEndX(a._1 + forward._1)
-        line.setEndY(a._2 + forward._2)
+        lineObj.setEndX(line.start.x + forward._1)
+        lineObj.setEndY(line.start.y + forward._2)
     }
 
     animation.play()
-    line
+    animation
 }

--- a/src/main/scala/ch/epfl/alcmp/gui/PathVisualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/PathVisualizer.scala
@@ -1,0 +1,31 @@
+package ch.epfl.alcmp.gui
+
+import javafx.animation.Transition
+import javafx.scene.layout.Pane
+import javafx.scene.shape.Line
+import javafx.util.Duration
+
+object PathVisualizer {
+
+  def visualize(parent: Pane, a: (Int, Int), b: (Int, Int)): Line =
+    val line = Line(a._1, a._2, a._1, a._2)
+    line.setStrokeWidth(2.5)
+
+    parent.getChildren.add(line)
+
+    val animation = new Transition() {
+      {
+        setCycleDuration(Duration.millis(1000))
+      }
+      override def interpolate(frac: Double): Unit =
+        val vector = (b._1 - a._1, b._2 - a._2)
+        //val finalLength = Math.sqrt((b._2 - a._2)*(b._2 - a._2) + (b._2 - a._2) * (b._2 - a._2))
+        val forward = (frac * vector._1, frac * vector._2)
+
+        line.setEndX(a._1 + forward._1)
+        line.setEndY(a._2 + forward._2)
+    }
+
+    animation.play()
+    line
+}

--- a/src/main/scala/ch/epfl/alcmp/gui/Visualizable.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/Visualizable.scala
@@ -1,0 +1,19 @@
+package ch.epfl.alcmp.gui
+
+import ch.epfl.alcmp.data.BinaryTree
+
+import scala.language.implicitConversions
+
+trait Visualizable
+
+case class VisualizableLine(start: Position, end: Position) extends Visualizable
+case class VisualizableList(list: List[Int]) extends Visualizable
+case class VisualizableMatrix(rows: List[List[Int]]) extends Visualizable
+case class VisualizableHeap(list: List[Int]) extends Visualizable
+case class VisualizableBinaryTree(root: BinaryTree[Int]) extends Visualizable
+
+implicit def lineToObj(line: (Position, Position)): VisualizableLine = VisualizableLine(line._1, line._2)
+implicit def listToObj(list: List[Int]): VisualizableList = VisualizableList(list)
+implicit def matrixToObj(rows: List[List[Int]]): VisualizableMatrix = VisualizableMatrix(rows)
+implicit def heapToObj(list: List[Int]): VisualizableHeap = VisualizableHeap(list)
+implicit def binaryTreeToObj(root: BinaryTree[Int]): VisualizableBinaryTree = VisualizableBinaryTree(root)

--- a/src/main/scala/ch/epfl/alcmp/gui/Visualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/Visualizer.scala
@@ -4,8 +4,17 @@ import javafx.animation.Animation
 import javafx.scene.layout.Pane
 import javafx.scene.Node
 
-trait Visualizer[T] {
+trait Visualizer[T <: Visualizable] {
   def visualize(parent: Pane, obj: T, pos: Position): Animation
+}
+
+object Visualizer {
+
+  given Visualizer[VisualizableList] = ListVisualizer
+  given Visualizer[VisualizableLine] = PathVisualizer
+
+  def visualize[T <: Visualizable](using v: Visualizer[T])(parent: Pane, obj: T, pos: Position): Animation =
+    v.visualize(parent, obj, pos)
 }
 
 opaque type Position = (Int, Int)

--- a/src/main/scala/ch/epfl/alcmp/gui/Visualizer.scala
+++ b/src/main/scala/ch/epfl/alcmp/gui/Visualizer.scala
@@ -1,0 +1,21 @@
+package ch.epfl.alcmp.gui
+
+import javafx.animation.Animation
+import javafx.scene.layout.Pane
+import javafx.scene.Node
+
+trait Visualizer[T] {
+  def visualize(parent: Pane, obj: T, pos: Position): Animation
+}
+
+opaque type Position = (Int, Int)
+object Position {
+
+  val NULL: Position = Position(-1, -1)
+
+  extension (pos: Position) {
+    def x: Int = pos._1
+    def y: Int = pos._2
+  }
+  def apply(pos: (Int, Int)): Position = pos
+}

--- a/src/test/scala/ch/epfl/alcmp/gui/CompositeVisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/CompositeVisualizerTest.scala
@@ -14,15 +14,15 @@ class CompositeVisualizerTest extends Scene {
     val button = Button("Next step")
     getChildren.add(button)
 
-    val top = List(1, 2, 3, 4)
-    val links: List[VisualizableList] = List(List(1, 2), List(1, 2))
+    val top: VisualizableList = List(1, 2, 3, 4)
+    val links: List[VisualizableList] = List(List(1, 2), List(3, 4))
 
     val topPos = Position(600, 100)
-    val linksPos = List(Position(300, 250), Position(900, 250))
+    val linksPos = List(Position(400, 300), Position(800, 300))
 
 
     button.setOnAction(_ => {
-      CompositeVisualizer.drawWithPath[VisualizableList](using ListVisualizer)(pane, top, links, topPos, linksPos)
+      CompositeVisualizer.drawWithPath[VisualizableList](using ListVisualizer)(pane, top, links, topPos, linksPos).play()
     })
   }
 

--- a/src/test/scala/ch/epfl/alcmp/gui/CompositeVisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/CompositeVisualizerTest.scala
@@ -1,0 +1,29 @@
+package ch.epfl.alcmp.gui
+import javafx.scene.control.Button
+import javafx.scene.shape.Circle
+import scalafx.scene.Scene
+import scalafx.scene.layout.{HBox, Pane, VBox}
+
+class CompositeVisualizerTest extends Scene {
+
+  {
+    val pane = new Pane()
+    pane.setPrefSize(1200, 900)
+    getChildren.add(pane)
+
+    val button = Button("Next step")
+    getChildren.add(button)
+
+    val top = List(1, 2, 3, 4)
+    val links: List[VisualizableList] = List(List(1, 2), List(1, 2))
+
+    val topPos = Position(600, 100)
+    val linksPos = List(Position(300, 250), Position(900, 250))
+
+
+    button.setOnAction(_ => {
+      CompositeVisualizer.drawWithPath[VisualizableList](using ListVisualizer)(pane, top, links, topPos, linksPos)
+    })
+  }
+
+}

--- a/src/test/scala/ch/epfl/alcmp/gui/CompositeVisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/CompositeVisualizerTest.scala
@@ -18,12 +18,11 @@ class CompositeVisualizerTest extends Scene {
     val links: List[VisualizableList] = List(List(1, 2), List(3, 4))
 
     val topPos = Position(600, 100)
-    val linksPos = List(Position(400, 300), Position(800, 300))
+    val linksPos = List(Position(400, 500), Position(800, 500))
 
 
     button.setOnAction(_ => {
-      CompositeVisualizer.drawWithPath[VisualizableList](using ListVisualizer)(pane, top, links, topPos, linksPos).play()
+      CompositeVisualizer.drawWithPath[VisualizableList](pane, top, links, topPos, linksPos).play()
     })
   }
-
 }

--- a/src/test/scala/ch/epfl/alcmp/gui/ListVisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/ListVisualizerTest.scala
@@ -1,0 +1,45 @@
+package ch.epfl.alcmp.gui
+import javafx.scene.control.Button
+import javafx.scene.shape.Circle
+import scalafx.scene.Scene
+import scalafx.scene.layout.{HBox, Pane, VBox}
+
+class ListVisualizerTest extends Scene {
+
+  {
+    val pane = new Pane()
+    pane.setPrefSize(1200, 900)
+    getChildren.add(pane)
+
+    val button = Button("Next step")
+    getChildren.add(button)
+
+
+
+    val list = fill(List(1, 2, 3, 4))
+    var i: Int = 0
+
+    val positions: List[(Int, Int)] = List(
+      (600, 50),
+      (400, 200), (800, 200),
+      (300, 350), (500, 350), (700, 350), (900, 350),
+    )
+    button.setOnAction(_ => {
+      ListVisualizer.visualize(pane, positions(i), list(i))
+      i += 1
+    })
+  }
+
+  def fill(list: List[Int]): List[List[Int]] =
+    var result: List[List[Int]] = Nil
+    var i = list.size
+    var j = 1
+    while i != 0 do {
+      for (sublist <- list.grouped(list.size / j)) {
+        result = result :+ sublist
+      }
+      j *= 2
+      i >>>= 1
+    }
+    result
+}

--- a/src/test/scala/ch/epfl/alcmp/gui/ListVisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/ListVisualizerTest.scala
@@ -14,8 +14,6 @@ class ListVisualizerTest extends Scene {
     val button = Button("Next step")
     getChildren.add(button)
 
-
-
     val list = fill(List(1, 2, 3, 4))
     var i: Int = 0
 
@@ -25,7 +23,7 @@ class ListVisualizerTest extends Scene {
       (300, 350), (500, 350), (700, 350), (900, 350),
     )
     button.setOnAction(_ => {
-      ListVisualizer.visualize(pane, positions(i), list(i))
+      ListVisualizer.visualize(pane, list(i), Position(positions(i)))
       i += 1
     })
   }

--- a/src/test/scala/ch/epfl/alcmp/gui/PathVisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/PathVisualizerTest.scala
@@ -15,7 +15,7 @@ class PathVisualizerTest extends Scene {
 
 
     button.setOnAction(_ => {
-      PathVisualizer.visualize(pane, (300, 400), (700, 200))
+      PathVisualizer.visualize(pane, (Position(300, 400), Position(700, 200)), Position.NULL)
     })
   }
 }

--- a/src/test/scala/ch/epfl/alcmp/gui/PathVisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/PathVisualizerTest.scala
@@ -1,0 +1,21 @@
+package ch.epfl.alcmp.gui
+import javafx.scene.control.Button
+import scalafx.scene.Scene
+import scalafx.scene.layout.Pane
+
+class PathVisualizerTest extends Scene {
+
+  {
+    val pane = new Pane()
+    pane.setPrefSize(1200, 900)
+    getChildren.add(pane)
+
+    val button = Button("Next step")
+    getChildren.add(button)
+
+
+    button.setOnAction(_ => {
+      PathVisualizer.visualize(pane, (300, 400), (700, 200))
+    })
+  }
+}

--- a/src/test/scala/ch/epfl/alcmp/gui/VisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/VisualizerTest.scala
@@ -14,7 +14,7 @@ object VisualizerTest extends JFXApp3 {
       title = "Algo Companion"
       width = ScalaFXMain.WIDTH
       height = ScalaFXMain.HEIGHT
-      scene = PathVisualizerTest()
+      scene = CompositeVisualizerTest()
       icons.add(new Image(ScalaFXMain.getClass.getResourceAsStream("/logo.png")))
     }
   }

--- a/src/test/scala/ch/epfl/alcmp/gui/VisualizerTest.scala
+++ b/src/test/scala/ch/epfl/alcmp/gui/VisualizerTest.scala
@@ -1,0 +1,21 @@
+package ch.epfl.alcmp.gui
+
+import ch.epfl.alcmp.gui.ScalaFXMain.stage
+import javafx.scene.image.Image
+import scalafx.application.JFXApp3
+
+object VisualizerTest extends JFXApp3 {
+
+  val WIDTH = 1200
+  val HEIGHT = 900
+
+  override def start(): Unit = {
+    stage = new JFXApp3.PrimaryStage {
+      title = "Algo Companion"
+      width = ScalaFXMain.WIDTH
+      height = ScalaFXMain.HEIGHT
+      scene = PathVisualizerTest()
+      icons.add(new Image(ScalaFXMain.getClass.getResourceAsStream("/logo.png")))
+    }
+  }
+}


### PR DESCRIPTION
- `Visualizable` represents an object that can be transformed into a JavaFX animated object
- `Visualizer` represents an object that can turn visualizables into JavaFX animated objects
- `CompositeVisualizable` is an example of one way we could construct composed animations, I'm not sure if we're going to use it as-is, because we probably won't want to render the "parent" at the same time as the "children"

To test the code, one needs to go to `VisualizerTest` and set the desired scene, either `ListVisualizerTest`, `PathVisualizerTest` or `CompositeVisualizerTest`.